### PR TITLE
run-shell: fix dbus environment

### DIFF
--- a/glue/bin/run-shell
+++ b/glue/bin/run-shell
@@ -28,6 +28,8 @@ miriway_config="$SNAP_USER_DATA/.config/miriway-shell.config"
 # Ensure we have a config file with the fixed options
 if [ ! -e "${miriway_config}" ]; then
 cat <<EOT > "${miriway_config}"
+shell-component=dbus-update-activation-environment --systemd --verbose WAYLAND_DISPLAY XDG_DATA_DIRS=/usr/local/share:/usr/share:/var/lib/snapd/desktop
+
 shell-ctrl-alt=a:wofi --show drun --location top_left
 shell-meta=a:wofi --show drun --location top_left
 shell-component=wayland-launch swaybg -i /snap/${SNAP_INSTANCE_NAME}/current/usr/share/backgrounds/warty-final-ubuntu.png


### PR DESCRIPTION
This is needed so that DBus-activated things (e.g. `snap userd`) work.

This makes things work (though with a ~30s delay, TBD) on https://github.com/canonical/ubuntu-core-desktop/