### PR TITLE
snap: rely on fonts from the snap

### DIFF
--- a/snap/local/plugs.json
+++ b/snap/local/plugs.json
@@ -1,5 +1,8 @@
 {
   "desktop-launch":{
     "allow-installation": "true"
+  },
+  "system-files":{
+    "allow-installation": "true"
   }
 }

--- a/snap/local/plugs.json
+++ b/snap/local/plugs.json
@@ -1,8 +1,5 @@
 {
   "desktop-launch":{
     "allow-installation": "true"
-  },
-  "system-files":{
-    "allow-installation": "true"
   }
 }

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -65,9 +65,12 @@ apps:
     slots:
       - wayland
     plugs:
+      - desktop-launch
+      - fonts
       - login-session-control
-      - x11
       - hardware-observe
+      - opengl
+      - x11
     environment:
       XDG_DATA_DIRS: $SNAP/usr/share:/var/lib/snapd/desktop
 
@@ -204,6 +207,12 @@ plugs:
     interface: content
     target: $SNAP/graphics
     default-provider: mesa-core22
+  fonts:
+    interface: system-files
+    read:
+      - /etc/fonts
+      - /usr/share/fonts
+      - /usr/share/fonts/truetype
 
 architectures:
   - build-on: amd64

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,10 +33,8 @@ environment:
   XKB_CONFIG_ROOT: $SNAP/usr/share/X11/xkb
 
 layout:
-  /usr/share/fonts/truetype/font-awesome:
-    symlink: $SNAP/usr/share/fonts/truetype/font-awesome
-  /usr/share/fonts/truetype/ubuntu:
-    symlink: $SNAP/usr/share/fonts/truetype/ubuntu
+  /usr/share/fonts:
+    bind: $SNAP/usr/share/fonts
   /usr/bin/xkbcomp:
     symlink: $SNAP/usr/bin/xkbcomp
   /usr/share/icons:
@@ -66,7 +64,6 @@ apps:
       - wayland
     plugs:
       - desktop-launch
-      - fonts
       - login-session-control
       - hardware-observe
       - opengl
@@ -205,12 +202,6 @@ plugs:
     interface: content
     target: $SNAP/graphics
     default-provider: mesa-core22
-  fonts:
-    interface: system-files
-    read:
-      - /etc/fonts
-      - /usr/share/fonts
-      - /usr/share/fonts/truetype
 
 architectures:
   - build-on: amd64

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -201,8 +201,6 @@ parts:
       - bin/graphics-core22-wrapper
 
 plugs:
-  desktop-launch:
-  opengl:
   graphics-core22:
     interface: content
     target: $SNAP/graphics


### PR DESCRIPTION
Rather than looking at system-wide fonts, just use the internal ones.

This has the disadvantage of not supporting fonts different than the
preinstalled ones, but system-files feels like the wrong solution
for that either way.

On Classic, access to the system snaps can be provided by the `desktop`
interface.