### PR TITLE
snap: SNAP_INSTANCE_NAME won't point at the snap contents

### DIFF
--- a/glue/bin/run-shell
+++ b/glue/bin/run-shell
@@ -40,7 +40,7 @@ shell-component=dbus-update-activation-environment --systemd --verbose WAYLAND_D
 
 shell-ctrl-alt=a:wofi --show drun --location top_left
 shell-meta=a:wofi --show drun --location top_left
-shell-component=wayland-launch swaybg -i /snap/${SNAP_INSTANCE_NAME}/current/usr/share/backgrounds/warty-final-ubuntu.png
+shell-component=wayland-launch swaybg -i ${SNAP}/usr/share/backgrounds/warty-final-ubuntu.png
 shell-component=wayland-launch yambar
 app-env-amend=XCURSOR_THEME=DMZ-White
 


### PR DESCRIPTION
/snap only ever has the main instance.