### PR TITLE
config: drop dbus-update..., it's not allowed to work

### DIFF
--- a/glue/bin/run-shell
+++ b/glue/bin/run-shell
@@ -36,8 +36,6 @@ yambar_config="$SNAP_USER_DATA/.config/yambar/config.yml"
 
 # Ensure we have a config file with the fixed options
 cat <<EOT > "${miriway_config}"
-shell-component=dbus-update-activation-environment --systemd --verbose WAYLAND_DISPLAY XDG_DATA_DIRS=/usr/local/share:/usr/share:/var/lib/snapd/desktop MOZ_ENABLE_WAYLAND
-
 shell-ctrl-alt=a:wofi --show drun --location top_left
 shell-meta=a:wofi --show drun --location top_left
 shell-component=wayland-launch swaybg -i /snap/${SNAP_INSTANCE_NAME}/current/usr/share/backgrounds/warty-final-ubuntu.png


### PR DESCRIPTION
```
dbus-update-activation-environment: error sending to dbus-daemon: org.freedesktop.DBus.Error.AccessDenied:
An AppArmor policy prevents this sender from sending this message to this recipient; type="method_call",
sender=":1.42" (uid=1001 pid=35514 comm="dbus-update-activation-environment MOZ_ENABLE_WAYL"
label="snap.confined-shell.confined-shell (enforce)") interface="org.freedesktop.DBus"
member="UpdateActivationEnvironment" error name="(unset)" requested_reply="0" destination="org.freedesktop.DBus" (bus)
```