### PR TITLE
FIx edge

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -90,10 +90,15 @@ parts:
       - libmiral-dev
       - g++
     stage-packages:
-      - libmiral6
       - mir-graphics-drivers-desktop
       - mir-graphics-drivers-nvidia
-    stage:
+      # Stage libmiral<n> indirectly as we cannot (since core22) do `try:/else:`
+      - libmiral-dev
+    prime:
+      # Do not prime the `-dev` part of libmiral-dev, we don't need it (just the libmiral<n> dependency)
+      - -usr/include
+      - -usr/lib/*/pkgconfig
+      - -usr/lib/*/libmir*.so
       - -usr/share/wayland-sessions/miriway.desktop
 
   wofi:


### PR DESCRIPTION
Mir on main is libmiral7, on release it is libmiral6. We need to pick the right one.