### PR TITLE
snap: add missing dependencies

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -86,7 +86,9 @@ parts:
     build-packages:
       - build-essential
       - pkg-config
+      - libboost-dev
       - libmiral-dev
+      - libmirwayland-dev
       - g++
     stage-packages:
       - mir-graphics-drivers-desktop


### PR DESCRIPTION
Something in the dependency chain changed, need to bring those in now.